### PR TITLE
Standardize readme and terminal output before comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,35 +30,27 @@ Seed subwiz with these subdomains:
 ### Supported Switches
 
 ```commandline
-usage: cli.py [-h] -i INPUT_FILE [-o OUTPUT_FILE] [-n NUM_PREDICTIONS]
-              [--no-resolve] [--force-download] [-t TEMPERATURE]
-              [-d {auto,cpu,cuda,mps}] [-q MAX_NEW_TOKENS]
-              [--resolution_concurrency RESOLUTION_LIM]
+usage: cli.py [-h] -i INPUT_FILE [-o OUTPUT_FILE] [-n NUM_PREDICTIONS] [--no-resolve] [--force-download] [-t TEMPERATURE] [-d {auto,cpu,cuda,mps}]
+              [-q MAX_NEW_TOKENS] [--resolution_concurrency RESOLUTION_LIM]
 
 options:
   -h, --help            show this help message and exit
   -i INPUT_FILE, --input-file INPUT_FILE
                         file containing new-line-separated subdomains.
-                        (default: None)
   -o OUTPUT_FILE, --output-file OUTPUT_FILE
                         output file to write new-line separated subdomains to.
-                        (default: None)
   -n NUM_PREDICTIONS, --num_predictions NUM_PREDICTIONS
-                        number of subdomains to predict. (default: 500)
-  --no-resolve          do not resolve the output subdomains. (default: False)
+                        number of subdomains to predict.
+  --no-resolve          do not resolve the output subdomains.
   --force-download      download model and tokenizer files, even if cached.
-                        (default: False)
   -t TEMPERATURE, --temperature TEMPERATURE
                         add randomness to the model, recommended ≤ 0.3)
-                        (default: 0.0)
   -d {auto,cpu,cuda,mps}, --device {auto,cpu,cuda,mps}
-                        hardware to run the transformer model on. (default:
-                        auto)
+                        hardware to run the transformer model on.
   -q MAX_NEW_TOKENS, --max_new_tokens MAX_NEW_TOKENS
                         maximum length of predicted subdomains in tokens.
-                        (default: 10)
   --resolution_concurrency RESOLUTION_LIM
-                        number of concurrent resolutions. (default: 128)
+                        number of concurrent resolutions.
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -30,27 +30,28 @@ Seed subwiz with these subdomains:
 ### Supported Switches
 
 ```commandline
-usage: cli.py [-h] -i INPUT_FILE [-o OUTPUT_FILE] [-n NUM_PREDICTIONS] [--no-resolve] [--force-download] [-t TEMPERATURE] [-d {auto,cpu,cuda,mps}]
-              [-q MAX_NEW_TOKENS] [--resolution_concurrency RESOLUTION_LIM]
+usage: cli.py [-h] -i INPUT_FILE [-o OUTPUT_FILE] [-n NUM_PREDICTIONS] [--no-resolve]
+              [--force-download] [-t TEMPERATURE] [-d {auto,cpu,cuda,mps}] [-q MAX_NEW_TOKENS]
+              [--resolution_concurrency RESOLUTION_LIM]
 
 options:
   -h, --help            show this help message and exit
   -i INPUT_FILE, --input-file INPUT_FILE
-                        file containing new-line-separated subdomains.
+                        file containing new-line-separated subdomains. (default: None)
   -o OUTPUT_FILE, --output-file OUTPUT_FILE
-                        output file to write new-line separated subdomains to.
+                        output file to write new-line separated subdomains to. (default: None)
   -n NUM_PREDICTIONS, --num_predictions NUM_PREDICTIONS
-                        number of subdomains to predict.
-  --no-resolve          do not resolve the output subdomains.
-  --force-download      download model and tokenizer files, even if cached.
+                        number of subdomains to predict. (default: 500)
+  --no-resolve          do not resolve the output subdomains. (default: False)
+  --force-download      download model and tokenizer files, even if cached. (default: False)
   -t TEMPERATURE, --temperature TEMPERATURE
-                        add randomness to the model, recommended ≤ 0.3)
+                        add randomness to the model, recommended ≤ 0.3) (default: 0.0)
   -d {auto,cpu,cuda,mps}, --device {auto,cpu,cuda,mps}
-                        hardware to run the transformer model on.
+                        hardware to run the transformer model on. (default: auto)
   -q MAX_NEW_TOKENS, --max_new_tokens MAX_NEW_TOKENS
-                        maximum length of predicted subdomains in tokens.
+                        maximum length of predicted subdomains in tokens. (default: 10)
   --resolution_concurrency RESOLUTION_LIM
-                        number of concurrent resolutions.
+                        number of concurrent resolutions. (default: 128)
 
 ```
 

--- a/subwiz/cli.py
+++ b/subwiz/cli.py
@@ -16,12 +16,7 @@ from subwiz.type import (
     temperature_type,
 )
 
-if not sys.stdout.isatty():
-    formatter_class = argparse.HelpFormatter  # Fixed width
-else:
-    formatter_class = argparse.ArgumentDefaultsHelpFormatter  # Dynamic width [3/4]
-
-parser = argparse.ArgumentParser(formatter_class=formatter_class)
+parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 parser.add_argument(
     "-i",
     "--input-file",

--- a/subwiz/cli.py
+++ b/subwiz/cli.py
@@ -1,7 +1,6 @@
 """Exposes a command line interface that runs subwiz and returns the result."""
 
 import argparse
-import sys
 
 from subwiz.main import (
     download_files,
@@ -15,6 +14,7 @@ from subwiz.type import (
     positive_int_type,
     temperature_type,
 )
+
 
 parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 parser.add_argument(

--- a/subwiz/cli.py
+++ b/subwiz/cli.py
@@ -1,6 +1,7 @@
 """Exposes a command line interface that runs subwiz and returns the result."""
 
 import argparse
+import sys
 
 from subwiz.main import (
     download_files,
@@ -15,8 +16,12 @@ from subwiz.type import (
     temperature_type,
 )
 
+if not sys.stdout.isatty():
+    formatter_class = argparse.HelpFormatter  # Fixed width
+else:
+    formatter_class = argparse.ArgumentDefaultsHelpFormatter  # Dynamic width [3/4]
 
-parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+parser = argparse.ArgumentParser(formatter_class=formatter_class)
 parser.add_argument(
     "-i",
     "--input-file",

--- a/tests/test_readme_switches.py
+++ b/tests/test_readme_switches.py
@@ -6,8 +6,10 @@ def test_():
         readme = f.read()
 
     result = subprocess.run(
-        ["python", "-m", "subwiz.cli", "-h"], capture_output=True, text=True
+        ["python", "-m", "subwiz.cli", "-h"], capture_output=True, text=True, env={**dict(subprocess.os.environ), "COLUMNS": "100"}
     )
     help_text = result.stdout
+
+    print(help_text)
 
     assert help_text in readme

--- a/tests/test_readme_switches.py
+++ b/tests/test_readme_switches.py
@@ -1,13 +1,5 @@
 import subprocess
 
-
-def standardize_text(text):
-    text = text.replace(" ", "")
-    text = text.replace("\t", "")
-    text = text.replace("\n", "")
-    return text
-
-
 def test_():
     with open("README.md", "r") as f:
         readme = f.read()
@@ -16,9 +8,5 @@ def test_():
         ["python", "-m", "subwiz.cli", "-h"], capture_output=True, text=True
     )
     help_text = result.stdout
-
-    # Sandardize texts
-    help_text = standardize_text(help_text)
-    readme = standardize_text(readme)
 
     assert help_text in readme

--- a/tests/test_readme_switches.py
+++ b/tests/test_readme_switches.py
@@ -1,10 +1,12 @@
 import subprocess
 
+
 def standardize_text(text):
     text = text.replace(" ", "")
     text = text.replace("\t", "")
     text = text.replace("\n", "")
     return text
+
 
 def test_():
     with open("README.md", "r") as f:
@@ -20,5 +22,3 @@ def test_():
     readme = standardize_text(readme)
 
     assert help_text in readme
-
-test_()

--- a/tests/test_readme_switches.py
+++ b/tests/test_readme_switches.py
@@ -6,7 +6,10 @@ def test_():
         readme = f.read()
 
     result = subprocess.run(
-        ["python", "-m", "subwiz.cli", "-h"], capture_output=True, text=True, env={**dict(subprocess.os.environ), "COLUMNS": "100"}
+        ["python", "-m", "subwiz.cli", "-h"],
+        capture_output=True,
+        text=True,
+        env={**dict(subprocess.os.environ), "COLUMNS": "100"},
     )
     help_text = result.stdout
 

--- a/tests/test_readme_switches.py
+++ b/tests/test_readme_switches.py
@@ -1,5 +1,6 @@
 import subprocess
 
+
 def test_():
     with open("README.md", "r") as f:
         readme = f.read()

--- a/tests/test_readme_switches.py
+++ b/tests/test_readme_switches.py
@@ -1,6 +1,10 @@
-import os
 import subprocess
 
+def standardize_text(text):
+    text = text.replace(" ", "")
+    text = text.replace("\t", "")
+    text = text.replace("\n", "")
+    return text
 
 def test_():
     with open("README.md", "r") as f:
@@ -11,4 +15,10 @@ def test_():
     )
     help_text = result.stdout
 
+    # Sandardize texts
+    help_text = standardize_text(help_text)
+    readme = standardize_text(readme)
+
     assert help_text in readme
+
+test_()


### PR DESCRIPTION
Readme tests failing/passing depends on terminal size for doing the comparison with the README file.
Standardize text outputs to avoid this.