### PR TITLE
Feature: Add Quiet and Silent CLI Options

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ Seed subwiz with these subdomains:
 ```commandline
 usage: cli.py [-h] -i INPUT_FILE [-o OUTPUT_FILE] [-n NUM_PREDICTIONS] [--no-resolve]
               [--force-download] [--max-recursion MAX_RECURSION] [-t TEMPERATURE]
-              [-d {auto,cpu,cuda,mps}] [-q MAX_NEW_TOKENS]
-              [--resolution-concurrency RESOLUTION_CONCURRENCY] [--multi-apex]
+              [-d {auto,cpu,cuda,mps}] [-m MAX_NEW_TOKENS]
+              [--resolution-concurrency RESOLUTION_CONCURRENCY] [--multi-apex] [-q] [-s]
 
 options:
   -h, --help            show this help message and exit
@@ -52,12 +52,14 @@ options:
                         add randomness to the model (recommended ≤ 0.3). (default: 0.0)
   -d {auto,cpu,cuda,mps}, --device {auto,cpu,cuda,mps}
                         hardware to run the transformer model on. (default: auto)
-  -q MAX_NEW_TOKENS, --max-new-tokens MAX_NEW_TOKENS
+  -m MAX_NEW_TOKENS, --max-new-tokens MAX_NEW_TOKENS
                         maximum length of predicted subdomains in tokens. (default: 10)
   --resolution-concurrency RESOLUTION_CONCURRENCY
                         number of concurrent resolutions. (default: 128)
   --multi-apex          allow multiple apex domains in the input file. runs inference for each
                         apex separately. (default: False)
+  -q, --quiet           useful for piping into another tool. (default: False)
+  -s, --silent          do not print any output. requires --output-file. (default: False)
 ```
 
 ### In Python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "subwiz"
-version = "0.4.1"
+version = "0.5.0"
 description = "A lightweight GPT model, trained to discover subdomains."
 readme = "README.md"
 requires-python = ">=3.9, <3.14"

--- a/subwiz/main.py
+++ b/subwiz/main.py
@@ -6,6 +6,7 @@ from collections import defaultdict
 from typing import Callable
 
 from huggingface_hub import hf_hub_download
+from huggingface_hub.utils import disable_progress_bars, enable_progress_bars
 import torch
 from transformers import PreTrainedTokenizerFast
 
@@ -32,8 +33,11 @@ CONFIG_FILE = "config.json"
 def get_model_and_tokenizer(
     force_download: bool,
     device: str,
+    quiet: bool,
 ) -> tuple[GPT, PreTrainedTokenizerFast]:
     """Download files from HuggingFace to run subwiz. Caches in local file system."""
+    if quiet:
+        disable_progress_bars()
 
     model_path = hf_hub_download(
         repo_id=MODEL_REPO, filename=MODEL_FILE, force_download=force_download
@@ -44,6 +48,8 @@ def get_model_and_tokenizer(
     hf_hub_download(
         repo_id=MODEL_REPO, filename=CONFIG_FILE, force_download=force_download
     )
+    if quiet:
+        enable_progress_bars()
 
     gpt_model = GPT.from_checkpoint(
         model_path, device=device, tokenizer_path=tokenizer_path
@@ -117,7 +123,7 @@ def _get_domains_for_group(
     temperature: float,
     no_resolve: bool,
     resolution_concurrency: int,
-    print_cli_progress: bool,
+    quiet: bool,
 ) -> set[str]:
     """For a group of subdomains that share an apex: run inference and check if they resolve, recursively."""
 
@@ -128,7 +134,7 @@ def _get_domains_for_group(
     for i in range(max_recursion):
 
         on_inference_iteration = None
-        if print_cli_progress:
+        if not quiet:
 
             dots_emitted = 0
 
@@ -158,14 +164,15 @@ def _get_domains_for_group(
         )
 
         if no_resolve:
-            print_log("", end="\n")
+            if not quiet:
+                print_log("", end="\n")
             return {str(dom) for dom in predictions}
 
         predictions_that_resolve = asyncio.run(
             get_registered_domains(predictions, resolution_concurrency)
         )
 
-        if print_cli_progress:
+        if not quiet:
             if not max_recursion:
                 end_log = ""
             else:
@@ -200,10 +207,10 @@ def run(
     force_download: bool = False,
     multi_apex: bool = False,
     max_recursion: int = 5,
-    print_cli_progress: bool = False,
+    quiet: bool = True,
 ) -> list[str]:
     """Check types, download model, get new subdomains for each apex."""
-    if print_cli_progress:
+    if not quiet:
         print_hello()
 
     domain_objects = input_domains_type(input_domains)
@@ -224,7 +231,9 @@ def run(
             "Use the --multi-apex flag to process them all."
         )
 
-    gpt_model, tokenizer = get_model_and_tokenizer(force_download, device=device)
+    gpt_model, tokenizer = get_model_and_tokenizer(
+        force_download, device=device, quiet=quiet
+    )
     found_domains = set()
 
     for apex in sorted(domain_groups):
@@ -240,7 +249,7 @@ def run(
             temperature=temperature,
             no_resolve=no_resolve,
             resolution_concurrency=resolution_concurrency,
-            print_cli_progress=print_cli_progress,
+            quiet=quiet,
         )
 
     return sorted(found_domains)

--- a/tests/test_cli_output.py
+++ b/tests/test_cli_output.py
@@ -1,0 +1,99 @@
+from subwiz import run
+from subwiz.type import Domain
+import subprocess
+import tempfile
+
+
+def test_quiet_output_with_force_download():
+    with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
+        f.write("a.hadrian.io\nb.hadrian.io")
+        input_file = f.name
+
+    command = [
+        "python",
+        "-m",
+        "subwiz.cli",
+        "-i",
+        input_file,
+        "--no-resolve",
+        "-n",
+        "10",
+        "-q",
+        "--force-download",
+    ]
+
+    result = subprocess.run(
+        command,
+        capture_output=True,
+        text=True,
+    )
+
+    # Check that we still get domain output
+    lines = result.stdout.strip().splitlines()
+    assert lines, "No domains found in output"
+    for line in lines:
+        Domain(line)
+
+
+def test_run_is_quiet_by_default(capsys):
+    results = run(
+        input_domains=["test.hadrian.io"],
+        num_predictions=1,
+        no_resolve=True,
+    )
+    assert results
+    captured = capsys.readouterr()
+    assert captured.out == ""
+
+
+def test_silent_output():
+    with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
+        f.write("a.hadrian.io\nb.hadrian.io")
+        input_file = f.name
+
+    with tempfile.NamedTemporaryFile(mode="w", delete=False) as out_f:
+        output_file = out_f.name
+
+    result = subprocess.run(
+        [
+            "python",
+            "-m",
+            "subwiz.cli",
+            "-i",
+            input_file,
+            "--no-resolve",
+            "-n",
+            "10",
+            "-s",
+            "-o",
+            output_file,
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.stdout == ""
+
+
+def test_silent_without_output_file():
+    with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
+        f.write("a.hadrian.io\nb.hadrian.io")
+        input_file = f.name
+
+    result = subprocess.run(
+        [
+            "python",
+            "-m",
+            "subwiz.cli",
+            "-i",
+            input_file,
+            "--no-resolve",
+            "-n",
+            "10",
+            "-s",
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    assert "error: --silent requires --output-file." in result.stderr


### PR DESCRIPTION
# Feature: Add Quiet and Silent CLI Options
This pull request introduces two new command-line arguments, `--quiet` and `--silent`, to provide users with more control over the application's output. This is particularly useful for integrating subwiz into automated security workflows and shell scripting, where verbose logging is often undesirable.

## Changes Implemented

### 1. Added New CLI Arguments:

- Introduced the `--quiet` (short form `-q`) flag to suppress all non-essential output, such as the ASCII art banner and progress logs. Only the final list of discovered subdomains is printed.
- Introduced the `--silent` (short form `-s`) flag to suppress all output to standard out. This requires the `--output-file` (`-o`) argument to be used, ensuring results are saved to a file.
- Added a validation check to ensure the application exits with an error if `--silent` is used without `--output-file`.

### 2. Resolved Argument Conflict:

- To accommodate the new `-q` flag for `--quiet`, the existing short-form argument for `--max-new-tokens` was changed from `-q` to `-m`.

### 3. Updated Core Logic:

- The main `run()` function in `subwiz/main.py` was updated to accept the quiet and silent boolean flags.
- The application's internal logging is now controlled by these flags, ensuring that progress indicators and other logs are only displayed when neither flag is present.

### 4. Updated Documentation and Tests:

- The README.md file was updated with the new command-line help text to reflect the added arguments.
- This change also fixed the failing `tests/test_readme_switches.py` test case, ensuring the documentation is in sync with the tool's functionality. All tests now pass.

Closes #18 